### PR TITLE
fixed typo in vsconfig get for api endpoint

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ let responsePreview: boolean | undefined;
 
 function updateVSConfig() {
 	VSConfig = vscode.workspace.getConfiguration("ollama-autocoder");
-	apiEndpoint = VSConfig.get("apiEndpoint") || "http://localhost:11434/api/generate";
+	apiEndpoint = VSConfig.get("endpoint") || "http://localhost:11434/api/generate";
 	apiModel = VSConfig.get("model") || "openhermes2.5-mistral:7b-q4_K_M"; // The model I tested with
 	apiSystemMessage = VSConfig.get("system message");
 	numPredict = VSConfig.get("max tokens predicted") || 500;


### PR DESCRIPTION
The api endpoint setting did not worked.
There was a small typo in the code, which resolved "apiEndpoint" setting, but the name of the setting in the package.json is "endpoint".