### PR TITLE
Use string for completion keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
 					"description": "The size of the prompt in characters. NOT tokens, so can be set 1.3-4x the max tokens of the model (varies significantly). If unsure, just use a 1:1 token size."
 				},
 				"ollama-autocoder.completion keys": {
-					"type": "array",
-					"default": [" "],
-					"description": "Characters that the autocompletion item provider appear on. '\\n' will be parsed as the newline character, REQUIRES RELOAD"
+					"type": "string",
+					"default": " ",
+					"description": "Character that the autocompletion item provider appear on. Multiple characters will be treated as different entries. '\\n' is parsed as the newline character. REQUIRES RELOAD"
 				},
 				"ollama-autocoder.response preview": {
 					"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ let apiMessageHeader: string;
 let apiTemperature: number;
 let numPredict: number;
 let promptWindowSize: number;
-let completionKeys: Array<string>;
+let completionKeys: string;
 let responsePreview: boolean | undefined;
 let responsePreviewMaxTokens: number;
 let responsePreviewDelay: number;
@@ -24,7 +24,7 @@ function updateVSConfig() {
 	apiMessageHeader = VSConfig.get("message header") || "";
 	numPredict = VSConfig.get("max tokens predicted") || 0;
 	promptWindowSize = VSConfig.get("prompt window size") || 0;
-	completionKeys = VSConfig.get("completion keys") || [" "];
+	completionKeys = VSConfig.get("completion keys") || " ";
 	responsePreview = VSConfig.get("response preview");
 	responsePreviewMaxTokens = VSConfig.get("preview max tokens") || 0;
 	responsePreviewDelay = VSConfig.get("preview delay") || 0; // Must be || 0 instead of || [default] because of truthy
@@ -258,7 +258,7 @@ function activate(context: vscode.ExtensionContext) {
 	const completionProvider = vscode.languages.registerCompletionItemProvider("*", {
 		provideCompletionItems
 	},
-		...completionKeys.map((s) => s.replace("\\n", "\n"))
+		...completionKeys.replace("\\n", "\n").split("")
 	);
 
 	// Bearer token secret handling


### PR DESCRIPTION
using a list did not have the intented UX,
instead it shows `Edit in settings.json`, where `\n` can already be used.