### PR TITLE
Use List for completion keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,13 @@
 					"description": "The size of the prompt in characters. NOT tokens, so can be set 1.3-4x the max tokens of the model (varies significantly). If unsure, just use a 1:1 token size."
 				},
 				"ollama-autocoder.completion keys": {
-					"type": "string",
-					"default": " ",
-					"description": "Character that the autocompletion item provider appear on. Multiple characters will be treated as different entries. '\\n' is parsed as the newline character. REQUIRES RELOAD"
+					"type": "array",
+					"items": {
+						"type": "string",
+						"title": "completion key"
+					},
+					"default": [" "],
+					"description": "Characters that the autocompletion item provider appear on. '\\n' is parsed as the newline character. REQUIRES RELOAD"
 				},
 				"ollama-autocoder.response preview": {
 					"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ let apiMessageHeader: string;
 let apiTemperature: number;
 let numPredict: number;
 let promptWindowSize: number;
-let completionKeys: string;
+let completionKeys: Array<string>;
 let responsePreview: boolean | undefined;
 let responsePreviewMaxTokens: number;
 let responsePreviewDelay: number;
@@ -24,7 +24,7 @@ function updateVSConfig() {
 	apiMessageHeader = VSConfig.get("message header") || "";
 	numPredict = VSConfig.get("max tokens predicted") || 0;
 	promptWindowSize = VSConfig.get("prompt window size") || 0;
-	completionKeys = VSConfig.get("completion keys") || " ";
+	completionKeys = VSConfig.get("completion keys") || [" "];
 	responsePreview = VSConfig.get("response preview");
 	responsePreviewMaxTokens = VSConfig.get("preview max tokens") || 0;
 	responsePreviewDelay = VSConfig.get("preview delay") || 0; // Must be || 0 instead of || [default] because of truthy
@@ -258,7 +258,7 @@ function activate(context: vscode.ExtensionContext) {
 	const completionProvider = vscode.languages.registerCompletionItemProvider("*", {
 		provideCompletionItems
 	},
-		...completionKeys.replace("\\n", "\n").split("")
+		...completionKeys.map((s) => s.replace("\\n", "\n"))
 	);
 
 	// Bearer token secret handling


### PR DESCRIPTION
i knew i saw a list option somewhere before, was missing description of items
<img width="992" height="148" alt="Screenshot From 2026-04-08 13-12-48" src="https://github.com/user-attachments/assets/4e78dbe9-bedb-4fd0-9283-81b7a21bf023" />

sorry for the churn.